### PR TITLE
Fixed and updated vala nextflow pipeline

### DIFF
--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -1,4 +1,4 @@
-default_icores = 4
+default_icores = 8
 default_mpitasks = 1
 default_pcores = 8
 default_ptime = '12h'
@@ -8,18 +8,18 @@ default_mem_sc = '8G' // a good lower bound in Mb is: (N ^ 2 * 8) / (1024 ^ 2)
 default_mem_mc = '16G' // ARACNE and CLR will need much more. Look above for a lower bound
 default_batchsize = 20 // a good value is N/200
 default_ensemble_size = 1000
-default_preamble = ''
-default_epilog = '' 
-process.executor = 'local' // change to 'slurm' for SLURM
+default_preamble = ' ' //ex. export OMP_NUM_THREAD=4 
+default_epilog = ' ' 
+process.executor = 'slurm' // change to 'slurm' for SLURM
 
 params {
   
   expr = 'headless.tsv'
   genes = 'genes.tsv'
   out = 'results'
-  targets = 'targets.txt'
+  targets = '' // empty if not specific targets
   slurm_account = 'facility'
-  slurm_partition = 'node'
+  slurm_partition = 'core'
   slurm_time = '05:00:00'
   executor = process.executor
   error_strategy = 'ignore'
@@ -40,6 +40,23 @@ params {
     epilog = default_epilog
   }
 
+  mi = true
+  mi_settings {
+    tasks = default_mpitasks
+    cores = default_pcores
+    memory = default_mem_mc
+    importcores = default_icores
+    importmem = default_importmem
+    bins = 0 // auto setting
+    spline = 3
+    importname = 'MI'
+    batchsize = default_batchsize
+    ptime = default_ptime
+    itime = default_itime
+    preamble = default_preamble
+    epilog = default_epilog
+  }
+
   aracne = true
   aracne_settings {
     tasks = default_mpitasks
@@ -47,7 +64,7 @@ params {
     memory = default_mem_mc
     importcores = default_icores
     importmem = default_importmem
-    bins = 0
+    bins = 0 // auto setting
     spline = 3
     importname = 'ARACNE'
     batchsize = default_batchsize
@@ -64,7 +81,7 @@ params {
     memory = default_mem_mc
     importcores = default_icores
     importmem = default_importmem
-    bins = 0
+    bins = 0 // auto setting
     spline = 3
     importname = 'CLR'
     batchsize = default_batchsize
@@ -82,7 +99,7 @@ params {
     importcores = default_icores
     importmem = default_importmem
     // -s if data should be scaled
-    scale = '-s' 
+    scale = '' 
     // -a if data should be reported as absolute values
     absolute = ''
     importname = 'Pearson'
@@ -100,7 +117,7 @@ params {
     importcores = default_icores
     importmem = default_importmem
     // -s if data should be scaled
-    scale = '-s' 
+    scale = '' 
     // -a if data should be reported as absolute values
     absolute = ''
     importname = 'Spearman'
@@ -118,7 +135,7 @@ params {
     importcores = default_icores
     importmem = default_importmem
     // -s if data should be scaled
-    scale = '-s' 
+    scale = '' 
     importname = 'ElNet'
     min_lambda = 0.3
     alpha = 0.3
@@ -143,7 +160,7 @@ params {
     importcores = default_icores
     importmem = default_importmem
     // -s if data should be scaled
-    scale = '-s' 
+    scale = '' 
     importname = 'SVM'
     max_experiment_size = 0 //auto
     min_experiment_size = 0 //auto
@@ -165,7 +182,7 @@ params {
     importcores = default_icores
     importmem = default_importmem
     // -s if data should be scaled
-    scale = '-s' 
+    scale = '' 
     importname = 'LLR'
     max_experiment_size = 0 //auto
     min_experiment_size = 0 //auto
@@ -222,7 +239,7 @@ params {
     importname = 'Tigress'
     batchsize = default_batchsize
     // -s if data should be scaled
-    scale = '-s' 
+    scale = '' 
     nlambda = 5
     min_lambda = 0.3
     nbootstrap = default_ensemble_size
@@ -242,7 +259,7 @@ params {
     importname = 'GENIE3'
     batchsize = default_batchsize
     // -s if data should be scaled
-    scale = '-s' 
+    scale = '' 
     min_prop = 0.1
     alpha = 0.5
     min_node_size = 5
@@ -264,7 +281,7 @@ params {
     importname = 'PLSNET'
     batchsize = default_batchsize
     // -s if data should be scaled
-    scale = '-s' 
+    scale = '' 
     components = 5
     predictors = 0 //auto
     ensemble = default_ensemble_size
@@ -273,5 +290,41 @@ params {
     preamble = default_preamble
     epilog = default_epilog
   }
+
+  tomsimilarity = true
+  tomsimilarity_settings {
+    tasks = default_mpitasks
+    cores = default_pcores
+    memory = default_mem_mc
+    importcores = default_icores
+    importmem = default_importmem 
+    importname = 'tomsimilarity'
+    batchsize = default_batchsize
+    // -S to not transform to z-scores
+    scale = '' 
+    method = 'pearson'
+    // -a if data should be reported as absolute values
+    absolute = ''
+    sft = 0 //autodetection
+    max_power = 30
+    sftcutoff = 0.8
+    tomtype = 'signed'
+    ptime = default_ptime
+    itime = default_itime
+    preamble = default_preamble
+    epilog = default_epilog
+  }
+
+  aggregate = true
+  aggregate_settings {
+   tasks = default_mpitasks
+    cores = default_pcores
+    memory = default_mem_mc
+    time = default_itime
+    method = 'irp'
+    keep = '' // --keep to keep directonality info
+    preamble = default_preamble
+    epilog = default_epilog
+ }
 
 }


### PR DESCRIPTION
Vala has been updated and tested to work with nextflow version 20.01.0.5264
Vala now includes tomsimilarity and mi as another network.
ARACNE and CLR gets the raw MI matrix from the MI run to speed up the process.
Seidr aggregate is now included, it gets executed at the end of the pipeline if all previous seidr import processes were successful. 